### PR TITLE
2.1.1 Correção de url para ver logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "2.1.0" # This tag will be updated by the action // TODO Update this value
+        custom_tag: "2.1.1" # This tag will be updated by the action // TODO Update this value
 
     # Generate new release
     - name: Generate new Release

--- a/Admin/PGPFGForGivewpAdmin.php
+++ b/Admin/PGPFGForGivewpAdmin.php
@@ -67,7 +67,7 @@ final class PGPFGForGivewpAdmin {
         switch (give_get_current_setting_section()) {
             case 'lkn-payment-pix':
                 // Verifique se a configuração específica já está no array
-                wp_enqueue_script('PGPFGForGivewpAdminSettingsScript', plugin_dir_url(__FILE__) . 'js/PGPFGForGivewpAdminSettings.js', array('jquery'), $this->version, false);
+                wp_enqueue_script('PGPFGForGivewpAdminSettingsScript', plugin_dir_url(__FILE__) . 'js/PGPFGForGivewpAdminSettings.js', array('jquery', 'wp-api'), $this->version, false);
 
                 $translation_array = array(
                     'seeLogs' => __('See logs', 'payment-gateway-pix-for-givewp')

--- a/Admin/js/PGPFGForGivewpAdminSettings.js
+++ b/Admin/js/PGPFGForGivewpAdminSettings.js
@@ -38,7 +38,7 @@ const lknPaymentPixLogSettingLabel = document.querySelector('label[for="lkn-paym
 if (lknPaymentPixLogSettingLabel) {
     const link = document.createElement('a');
     link.setAttribute('target', '_blank');
-    link.setAttribute('href', 'https://wordpress.local/wp-admin/edit.php?post_type=give_forms&page=give-tools&tab=logs');
+    link.setAttribute('href', wpApiSettings.root.replace('/wp-json/', '/wp-admin/edit.php?post_type=give_forms&page=give-tools&tab=logs'));
     link.innerHTML = pgpfgTranslations.seeLogs;
     lknPaymentPixLogSettingLabel.innerHTML += '<br>';
     lknPaymentPixLogSettingLabel.appendChild(link);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.1 - 26/02/2025
+* Correção de url para ver logs.
+
 # 2.1.0 - 09/11/2024
 * Adição de svg para mostrar configurações PRO;
 * Adição de script para alterar os estilos das configurações.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/
 Tags: gateway, payments, givewp
 Requires at least: 6.0
 Tested up to: 6.7
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 Requires PHP: 7.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -66,6 +66,10 @@ The Payment Gateway Pix for GiveWP is now activated.
  2. Form view (donate to us)
 
 == Changelog ==
+= 2.1.1 =
+**26/02/2025**
+* Fix URL to view logs.
+
 = 2.1.0 =
 **09/11/2024**
 * Add svg to show PRO settings;
@@ -98,6 +102,9 @@ The Payment Gateway Pix for GiveWP is now activated.
 * Added debug mode for advanced users.
 
 == Upgrade Notice ==
+= 2.1.1 =
+* Fix URL to view logs.
+
 = 2.1.0 =
 * Add svg to show PRO settings;
 * Add script to change settings styles.

--- a/payment-gateway-pix-for-givewp.php
+++ b/payment-gateway-pix-for-givewp.php
@@ -20,6 +20,7 @@
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com.br/
  * License:           GPL-3.0+
+ * Requires Plugins: give
  * License URI:       http://www.gnu.org/licenses/gpl-3.0.txt
  * Text Domain:       payment-gateway-pix-for-givewp
  * Domain Path:       /languages

--- a/payment-gateway-pix-for-givewp.php
+++ b/payment-gateway-pix-for-givewp.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Payment Gateway Pix for GiveWP
  * Plugin URI:        https://www.linknacional.com.br/wordpress/givewp/
  * Description:       Streamline your donation process and expand your reach to Brazilian donors by integrating PIX, the instant payment system, into your GiveWP donation forms.
- * Version:           2.1.0
+ * Version:           2.1.1
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com.br/
  * License:           GPL-3.0+
@@ -41,7 +41,7 @@ use Pgpfg\PGPFGForGivewp\Includes\PGPFGForGivewpDeactivator;
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('PGPFG_PIX_PLUGIN_VERSION', '2.1.0');
+define('PGPFG_PIX_PLUGIN_VERSION', '2.1.1');
 define('PGPFG_PIX_PLUGIN_FILE', __FILE__);
 define('PGPFG_PIX_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('PGPFG_PIX_PLUGIN_DIR', plugin_dir_path(__FILE__));


### PR DESCRIPTION
- Correção de url para ver logs
> Ajustada a URL de acesso aos logs, que antes redirecionava para o endereço errado.
![image](https://github.com/user-attachments/assets/9b181710-2c52-45f2-b58b-50d2c368435f)
