### PR TITLE
2.2.4 - payment-gateway-pix-for-givewp (Correção de segurança na rota PagHiper + Padrões Wordpress)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,3 +68,4 @@ jobs:
         draft: true
         tag: ${{ steps.tag_version.outputs.new_tag }}
         name: Release ${{ steps.tag_version.outputs.new_tag }}
+        


### PR DESCRIPTION
# Payment Gateway Pix for Givewp
Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, gateway, pix, payment

Testado até: 6.9.1

Versão estável: 2.2.4

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

Realiza a verificação e a prevenção de doações maliciosas.

## Descrição
Implementa a opção de doação via Pix para o GiveWP, garantindo mais captação para campanhas com foco em doações de brasileiros.

## Instalação
1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".

## Resumo(2.2.4):

* Correção de segurança na rota de status do PagHiper.
* Ajustes para se adequar aos padrões do WordPress.